### PR TITLE
fix: cron stdout parsing and last output from transcripts

### DIFF
--- a/routes/activity.js
+++ b/routes/activity.js
@@ -84,8 +84,10 @@ router.get('/', async (req, res) => {
 
     // 3. Cron job last runs
     try {
-      const cronOutput = execSync('openclaw cron list --json 2>/dev/null || echo "[]"', { timeout: 5000 }).toString();
-      const crons = JSON.parse(cronOutput);
+      const cronRaw = execSync('openclaw cron list --json 2>/dev/null', { timeout: 5000, encoding: 'utf8' });
+      // Strip any non-JSON prefix (doctor warnings can print to stdout)
+      const jsonStart = cronRaw.indexOf('{');
+      const crons = JSON.parse(jsonStart >= 0 ? cronRaw.slice(jsonStart) : cronRaw);
       for (const job of (Array.isArray(crons) ? crons : crons.jobs || [])) {
         if (job.lastRun || job.lastRunAt) {
           feed.push({

--- a/routes/cron.js
+++ b/routes/cron.js
@@ -1,15 +1,18 @@
 'use strict';
+const fs = require('fs');
+const path = require('path');
 const { execSync } = require('child_process');
 const express = require('express');
-const { GATEWAY_PORT, GATEWAY_TOKEN } = require('../lib/config');
+const { GATEWAY_PORT, GATEWAY_TOKEN, OPENCLAW_DIR } = require('../lib/config');
 const cache = require('../lib/cache');
-const { gatewayInvoke } = require('../lib/helpers');
+const { gatewayInvoke, readJSON, getLastAssistantMessage } = require('../lib/helpers');
 
 const router = express.Router();
 
 function parseCronJobs(parsed) {
   return (parsed.jobs || []).map(j => ({
     id: j.id,
+    agentId: j.agentId || 'main',
     name: j.name || j.id.substring(0, 8),
     schedule: j.schedule?.expr || j.schedule?.kind || '?',
     status: !j.enabled ? 'disabled' : (j.state?.lastStatus === 'ok' ? 'active' : j.state?.lastStatus || 'idle'),
@@ -18,25 +21,49 @@ function parseCronJobs(parsed) {
     duration: j.state?.lastDurationMs ? `${j.state.lastDurationMs}ms` : null,
     target: j.sessionTarget || 'main',
     payload: j.payload?.kind || '?',
-    description: j.payload?.text?.substring(0, 120) || '',
-    lastOutput: j.state?.lastOutput || j.state?.result || j.state?.output || '',
+    description: j.payload?.text?.substring(0, 120) || j.payload?.message?.substring(0, 120) || '',
+    lastOutput: '',
     lastStatus: j.state?.lastStatus || 'idle',
+    lastError: j.state?.lastError || '',
     history: [],
     enabled: j.enabled !== false,
   }));
 }
 
+async function getCronLastOutput(agentId, jobId) {
+  try {
+    const sessionsPath = path.join(OPENCLAW_DIR, 'agents', agentId, 'sessions', 'sessions.json');
+    const sessionsMap = await readJSON(sessionsPath, {});
+    const cronKey = `agent:${agentId}:cron:${jobId}`;
+    const session = sessionsMap[cronKey];
+    if (!session) return '';
+    const sessionId = session.sessionId ||
+      (session.sessionFile || '').split('/').pop().replace('.jsonl', '');
+    if (!sessionId) return '';
+    const transcriptPath = session.sessionFile ||
+      path.join(OPENCLAW_DIR, 'agents', agentId, 'sessions', `${sessionId}.jsonl`);
+    return await getLastAssistantMessage(transcriptPath);
+  } catch {
+    return '';
+  }
+}
+
 // ── GET /api/cron ─────────────────────────────────────────────────────────────
 
-router.get('/', (req, res) => {
+router.get('/', async (req, res) => {
   try {
     if (cache.cron && Date.now() - cache.cronTime < cache.CRON_TTL) {
       return res.json(cache.cron);
     }
-
-    const cronRaw = execSync('openclaw cron list --json 2>&1', { timeout: 10000, encoding: 'utf8' });
-    const parsed = JSON.parse(cronRaw);
-    const result = { jobs: parseCronJobs(parsed) };
+    const cronRaw = execSync('openclaw cron list --json 2>/dev/null', { timeout: 10000, encoding: 'utf8' });
+    // Strip any non-JSON prefix (doctor warnings can print to stdout)
+    const jsonStart = cronRaw.indexOf('{');
+    const parsed = JSON.parse(jsonStart >= 0 ? cronRaw.slice(jsonStart) : cronRaw);
+    const jobs = parseCronJobs(parsed);
+    await Promise.all(jobs.map(async job => {
+      job.lastOutput = await getCronLastOutput(job.agentId, job.id);
+    }));
+    const result = { jobs };
     cache.cron = result;
     cache.cronTime = Date.now();
     res.json(result);
@@ -52,15 +79,8 @@ router.post('/:id/toggle', async (req, res) => {
   try {
     const { id } = req.params;
     const { enabled } = req.body;
-
-    const response = await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'cron', {
-      action: 'update',
-      jobId: id,
-      patch: { enabled },
-    });
-
-    cache.cron = null;
-    cache.cronTime = 0;
+    await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'cron', { action: 'update', jobId: id, patch: { enabled } });
+    cache.cron = null; cache.cronTime = 0;
     res.json({ ok: true, message: `Job ${enabled ? 'enabled' : 'disabled'}` });
   } catch (error) {
     console.error('[Cron toggle]', error.message);
@@ -73,11 +93,8 @@ router.post('/:id/toggle', async (req, res) => {
 router.post('/:id/run', async (req, res) => {
   try {
     const { id } = req.params;
-
     await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'cron', { action: 'run', jobId: id });
-
-    cache.cron = null;
-    cache.cronTime = 0;
+    cache.cron = null; cache.cronTime = 0;
     res.json({ ok: true, message: 'Job triggered successfully' });
   } catch (error) {
     console.error('[Cron run]', error.message);
@@ -90,14 +107,9 @@ router.post('/:id/run', async (req, res) => {
 router.post('/create', async (req, res) => {
   try {
     const { job } = req.body;
-    if (!job?.name || !job?.schedule) {
-      return res.status(400).json({ error: 'Invalid job format - name and schedule required' });
-    }
-
+    if (!job?.name || !job?.schedule) return res.status(400).json({ error: 'Invalid job format - name and schedule required' });
     await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'cron', { action: 'add', job });
-
-    cache.cron = null;
-    cache.cronTime = 0;
+    cache.cron = null; cache.cronTime = 0;
     res.json({ ok: true, message: 'Job created successfully' });
   } catch (error) {
     console.error('[Cron create]', error.message);
@@ -110,11 +122,8 @@ router.post('/create', async (req, res) => {
 router.delete('/:id', async (req, res) => {
   try {
     const { id } = req.params;
-
     await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'cron', { action: 'remove', jobId: id });
-
-    cache.cron = null;
-    cache.cronTime = 0;
+    cache.cron = null; cache.cronTime = 0;
     res.json({ ok: true, message: 'Job deleted successfully' });
   } catch (error) {
     console.error('[Cron delete]', error.message);

--- a/server.js
+++ b/server.js
@@ -2,7 +2,6 @@
 const express = require('express');
 const path = require('path');
 const fs = require('fs');
-const { execSync } = require('child_process');
 
 // ── Config & shared state ─────────────────────────────────────────────────────
 const { TASKS_FILE, OPENCLAW_DIR } = require('./lib/config');
@@ -15,7 +14,6 @@ const statusRouter      = require('./routes/status');
 const { refreshStatusCache } = require('./routes/status');
 const sessionsRouter    = require('./routes/sessions');
 const cronRouter        = require('./routes/cron');
-const { parseCronJobs } = require('./routes/cron');
 const activityRouter    = require('./routes/activity');
 const tasksRouter       = require('./routes/tasks');
 const costsRouter       = require('./routes/costs');
@@ -106,17 +104,6 @@ app.listen(PORT, BIND_HOST, async () => {
 
   // Pre-warm caches in background — don't block startup
   setTimeout(() => refreshStatusCache(), 50);
-
-  setTimeout(() => {
-    try {
-      const cronRaw = execSync('openclaw cron list --json 2>&1', { timeout: 10000, encoding: 'utf8' });
-      cache.cron = { jobs: parseCronJobs(JSON.parse(cronRaw)) };
-      cache.cronTime = Date.now();
-      console.log(`[Startup] Pre-warmed ${cache.cron.jobs.length} cron jobs`);
-    } catch (e) {
-      console.warn('[Startup] Cron pre-warm failed:', e.message);
-    }
-  }, 100);
 
   setTimeout(async () => {
     try {


### PR DESCRIPTION
## Problem

Two bugs in the cron monitor:

### 1. Cron page silently empty
`openclaw cron list --json` is called with `2>&1` which redirects stderr to stdout. When OpenClaw prints doctor warnings to stdout (a known issue with the state dir migration warning), the JSON output gets prefixed with box-drawing characters, breaking `JSON.parse()`. The cron page shows nothing with no visible error.

**Fix:** Changed to `2>/dev/null` (correct redirect) and added `output.indexOf('{')` stripping to handle any remaining stdout prefix.

### 2. "Last Output" always empty
`parseCronJobs` tried to read `j.state.lastOutput`, `j.state.result`, and `j.state.output` — none of these fields exist in OpenClaw's cron state object. The actual output of a cron job lives in its session transcript (`.jsonl` file).

**Fix:** Added `getCronLastOutput(agentId, jobId)` which reads the cron session from `agents/<agentId>/sessions/sessions.json`, then reads the last assistant message from the `.jsonl` transcript via the existing `getLastAssistantMessage()` helper. Runs in parallel for all jobs via `Promise.all()`.

Also removed the startup cron prewarm in `server.js` that was caching empty output on boot and preventing the fix from running.