### PR TITLE
fix: read sessions and history from all agent directories

### DIFF
--- a/lib/gateway.js
+++ b/lib/gateway.js
@@ -7,33 +7,43 @@ const { gatewayInvoke } = require('./helpers');
 // ── Sessions ──────────────────────────────────────────────────────────────────
 
 async function fetchSessions(limit = 50) {
+  // Read sessions from ALL agent directories on disk
+  // (gateway sessions_list only returns the current agent's session context)
   try {
-    const data = await gatewayInvoke(GATEWAY_PORT, GATEWAY_TOKEN, 'sessions_list', { limit, messageLimit: 1 });
-    if (data?.sessions) return data;
-    if (Array.isArray(data)) return { count: data.length, sessions: data };
-  } catch (e) {
-    console.error('[fetchSessions] Gateway API failed:', e.message);
-  }
+    const agentsDir = path.join(OPENCLAW_DIR, 'agents');
+    const agentDirs = await fs.promises.readdir(agentsDir);
+    const allSessions = [];
 
-  // Fallback: read sessions.json directly
-  try {
-    const sessionsPath = path.join(OPENCLAW_DIR, 'agents/main/sessions/sessions.json');
-    const raw = await fs.promises.readFile(sessionsPath, 'utf8');
-    const sessionsMap = JSON.parse(raw);
-    const sessions = Object.entries(sessionsMap).slice(0, limit).map(([key, s]) => ({
-      key,
-      kind: s.kind || 'unknown',
-      channel: s.channel || 'unknown',
-      displayName: s.displayName || key.split(':').slice(-1)[0],
-      model: s.model || '',
-      totalTokens: s.totalTokens || 0,
-      contextTokens: s.contextTokens || 0,
-      updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : null,
-      label: s.label || null,
-    }));
+    for (const agentId of agentDirs) {
+      const sessionsPath = path.join(agentsDir, agentId, 'sessions', 'sessions.json');
+      try {
+        const raw = await fs.promises.readFile(sessionsPath, 'utf8');
+        const sessionsMap = JSON.parse(raw);
+        for (const [key, s] of Object.entries(sessionsMap)) {
+          allSessions.push({
+            key,
+            agentId,
+            kind: s.kind || 'unknown',
+            channel: s.channel || 'unknown',
+            displayName: s.displayName || key.split(':').slice(-1)[0],
+            model: s.model || '',
+            totalTokens: s.totalTokens || 0,
+            contextTokens: s.contextTokens || 0,
+            updatedAt: s.updatedAt ? new Date(s.updatedAt).toISOString() : null,
+            label: s.label || null,
+          });
+        }
+      } catch {
+        // skip agents with no sessions file
+      }
+    }
+
+    const sessions = allSessions
+      .sort((a, b) => (b.updatedAt || '') > (a.updatedAt || '') ? 1 : -1)
+      .slice(0, limit);
     return { count: sessions.length, sessions };
-  } catch (e2) {
-    console.error('[fetchSessions] Disk fallback failed:', e2.message);
+  } catch (e) {
+    console.error('[fetchSessions] Disk read failed:', e.message);
     return { count: 0, sessions: [] };
   }
 }

--- a/routes/sessions.js
+++ b/routes/sessions.js
@@ -25,7 +25,7 @@ router.get('/', async (req, res) => {
       return res.json(cache.sessions);
     }
 
-    const sessionData = await fetchSessions(25);
+    const sessionData = await fetchSessions(200);
     const sessions = sessionData.sessions || [];
 
     let result = {
@@ -33,9 +33,12 @@ router.get('/', async (req, res) => {
       sessions: sessions.map(s => {
         const key = s.key || '';
         const type = key.includes(':subagent:') ? 'sub-agent'
+          : key.includes(':cron:') ? 'cron'
           : key.includes(':discord:') ? 'discord'
           : key.includes(':openai') ? 'web'
-          : key.includes(':main:main') ? 'main'
+          : key.includes(':telegram:') ? 'telegram'
+          : key.includes(':whatsapp:') ? 'whatsapp'
+          : key.match(/agent:\w+:main$/) ? 'main'
           : 'other';
         return {
           key: s.key,
@@ -72,16 +75,23 @@ router.get('/:sessionKey/history', async (req, res) => {
     let sessionKey;
     try { sessionKey = decodeURIComponent(req.params.sessionKey); }
     catch { return res.status(400).json({ error: 'Invalid session key encoding' }); }
-    const cfg = await readJSON(path.join(OPENCLAW_DIR, 'openclaw.json'), {});
-    const gwToken = cfg.gateway?.auth?.token || process.env.MC_GATEWAY_TOKEN || GATEWAY_TOKEN;
-    const gwPort = cfg.gateway?.port || GATEWAY_PORT;
+    // Extract agentId from key: "agent:<agentId>:..."
+    const keyParts = sessionKey.split(':');
+    const agentId = keyParts.length >= 2 ? keyParts[1] : 'main';
 
-    const parsed = await gatewayInvoke(gwPort, gwToken, 'sessions_list', { limit: 100, messageLimit: 0 });
-    const session = (parsed?.sessions || []).find(s => s.key === sessionKey);
+    // Read the session record from the agent's sessions.json on disk
+    const sessionsPath = path.join(OPENCLAW_DIR, 'agents', agentId, 'sessions', 'sessions.json');
+    const sessionsMap = await readJSON(sessionsPath, {});
+    const session = sessionsMap[sessionKey];
 
-    if (!session?.transcriptPath) return res.json({ messages: [], info: 'No transcript found' });
+    if (!session) return res.json({ messages: [], info: 'Session not found' });
 
-    const transcriptFile = path.join(OPENCLAW_DIR, 'agents/main/sessions', session.transcriptPath);
+    // Use sessionFile (absolute path) if present, otherwise build from sessionId
+    let transcriptFile = session.sessionFile;
+    if (!transcriptFile && session.sessionId) {
+      transcriptFile = path.join(OPENCLAW_DIR, 'agents', agentId, 'sessions', `${session.sessionId}.jsonl`);
+    }
+    if (!transcriptFile) return res.json({ messages: [], info: 'No transcript found' });
     if (!fs.existsSync(transcriptFile)) return res.json({ messages: [], info: 'Transcript file missing' });
 
     const raw = await fs.promises.readFile(transcriptFile, 'utf8');


### PR DESCRIPTION
## Problem

Mission Control only shows sessions and conversation history for the primary (`main`) agent. Users with multiple agents configured (e.g. a research agent, a strategy agent) see empty conversations for all non-primary agents.

### Root causes

1. **`fetchSessions()` in `lib/gateway.js`**: First tries `sessions_list` via the gateway tool, which only returns the session context of the *calling* agent. If that "succeeds" (even with 1 result), the fallback never triggers. The fallback itself only reads `agents/main/sessions/sessions.json`.

2. **`GET /:sessionKey/history` in `routes/sessions.js`**: Uses `gatewayInvoke('sessions_list')` to locate the transcript path, which again only surfaces main-agent sessions. It also looks for a `transcriptPath` field that doesn't exist on disk — the actual fields are `sessionFile` (absolute path) and `sessionId`.

## Fix

- `fetchSessions()` now reads `sessions.json` from every directory under `~/.openclaw/agents/`, merges and sorts by `updatedAt`, and returns up to the requested limit.
- History handler extracts `agentId` from the session key (`agent:<agentId>:<rest>`), reads that agent's `sessions.json` directly, and uses `sessionFile` or builds the path from `sessionId`.
- Sessions fetch limit bumped from 25 → 200; type detection extended to cover cron runs, telegram, whatsapp, and per-agent main sessions.